### PR TITLE
Add support for relocating krb5.conf and remove DES

### DIFF
--- a/configure_krb5.sh
+++ b/configure_krb5.sh
@@ -210,8 +210,7 @@ create_kdc_database() {
   log DEBUG "Generating cloudera-scm/admin principal for Cloudera Manager"
 
   $KADMIN_LOCAL >/dev/null <<EOF
-  addprinc -randkey cloudera-scm/admin
-  xst -k cmf.keytab cloudera-scm/admin
+  addprinc -pw cloudera cloudera-scm/admin
 EOF
 
   echo
@@ -283,7 +282,7 @@ install_krb_packages
 configure_kdc
 configure_krb_client
 create_kdc_database
-configure_cm_files
+#configure_cm_files
 start_services
 display_next_steps
 

--- a/tmpl/kadmin.tmpl
+++ b/tmpl/kadmin.tmpl
@@ -1,0 +1,3 @@
+KADMIND_ARGS=
+KRB5REALM=
+export KRB5_CONFIG=@@client_conf_file@@

--- a/tmpl/kdc.conf.tmpl
+++ b/tmpl/kdc.conf.tmpl
@@ -15,5 +15,5 @@
   # requires the enhanced security JCE policy file to be installed. You should
   # NOT run with this configuration in production or any real environment. You
   # have been warned.
-  supported_enctypes = aes128-cts:normal des3-hmac-sha1:normal arcfour-hmac:normal des-hmac-sha1:normal des-cbc-md5:normal des-cbc-crc:normal
+  supported_enctypes = aes128-cts:normal des3-hmac-sha1:normal arcfour-hmac:normal
  }

--- a/tmpl/krb5kdc.tmpl
+++ b/tmpl/krb5kdc.tmpl
@@ -1,0 +1,3 @@
+KRB5KDC_ARGS=
+KRB5REALM=
+export KRB5_CONFIG=@@client_conf_file@@


### PR DESCRIPTION
This is useful for deploying on environments where something like Centrify or Quest owns /etc/krb5.conf. Also, straight up DES should die in a fire.
